### PR TITLE
Wrong title in account page bug fix

### DIFF
--- a/src/routes/(admin)/account/(menu)/+page.svelte
+++ b/src/routes/(admin)/account/(menu)/+page.svelte
@@ -6,6 +6,10 @@
   adminSection.set("home")
 </script>
 
+<svelte:head>
+  <title>Account</title>
+</svelte:head>
+
 <h1 class="text-2xl font-bold mb-1">Dashboard</h1>
 <div class="alert alert-error max-w-lg mt-2">
   <svg

--- a/src/routes/(admin)/account/+layout.svelte
+++ b/src/routes/(admin)/account/+layout.svelte
@@ -18,8 +18,4 @@
   })
 </script>
 
-<svelte:head>
-  <title>Account</title>
-</svelte:head>
-
 <slot />


### PR DESCRIPTION
Thank you for the great boilerplate!
I was able to find a bug in a page title. This is the bug fix.

**Bug:**
The title of the Account (Home) page is not updated.

**Preconditions:**
1. The user is logged in
2. The user is at /

**Steps to reproduce:**
1. Click on Account
3. Click on Settings
4. Click on Home

**Expected result:**
The title of the Home (/account) page is Account
**Actual result:**
The title of the Home (/account) page is Settings