### PR TITLE
Change tailwind bottom margin to padding for layouts

### DIFF
--- a/src/routes/(admin)/account/create_profile/+page.svelte
+++ b/src/routes/(admin)/account/create_profile/+page.svelte
@@ -33,7 +33,7 @@
 </svelte:head>
 
 <div
-  class="text-center content-center max-w-lg mx-auto min-h-[100vh] mb-12 flex items-center place-content-center"
+  class="text-center content-center max-w-lg mx-auto min-h-[100vh] pb-12 flex items-center place-content-center"
 >
   <div class="flex flex-col w-64 lg:w-80">
     <div>

--- a/src/routes/(admin)/account/select_plan/+page.svelte
+++ b/src/routes/(admin)/account/select_plan/+page.svelte
@@ -7,7 +7,7 @@
 </svelte:head>
 
 <div
-  class="text-center content-center min-h-[100vh] mb-12 mt-4 flex items-center place-content-center"
+  class="text-center content-center min-h-[100vh] pb-12 mt-4 flex items-center place-content-center"
 >
   <div class="flex flex-col w-full px-6">
     <div>

--- a/src/routes/(marketing)/login/+layout.svelte
+++ b/src/routes/(marketing)/login/+layout.svelte
@@ -1,5 +1,5 @@
 <div
-  class="text-center content-center max-w-lg mx-auto min-h-[70vh] mb-12 flex items-center place-content-center"
+  class="text-center content-center max-w-lg mx-auto min-h-[70vh] pb-12 flex items-center place-content-center"
 >
   <div class="flex flex-col w-64 lg:w-80">
     <slot />


### PR DESCRIPTION
I noticed on the create profile page that because there wasn't enough content to overflow 100vh the layout pushed the bottom 3rem (48px) down making it scroll even-though there was nothing.

Changed margin to padding.

Before: (notice the scrollbar)
<img width="933" alt="image" src="https://github.com/CriticalMoments/CMSaasStarter/assets/6147400/cec6c18e-99d4-4211-8f8c-281924a8f011">

After:
<img width="925" alt="image" src="https://github.com/CriticalMoments/CMSaasStarter/assets/6147400/0ad837c1-8575-4b15-8b22-2dc38064d8c3">
