### PR TITLE
Add max 50 character limit to text input fields

### DIFF
--- a/src/routes/(admin)/account/(menu)/settings/edit_profile/+page.svelte
+++ b/src/routes/(admin)/account/(menu)/settings/edit_profile/+page.svelte
@@ -28,16 +28,19 @@
       label: "Name",
       initialValue: profile?.full_name ?? "",
       placeholder: "Your full name",
+      maxlength: 50,
     },
     {
       id: "companyName",
       label: "Company Name",
       initialValue: profile?.company_name ?? "",
+      maxlength: 50,
     },
     {
       id: "website",
       label: "Company Website",
       initialValue: profile?.website ?? "",
+      maxlength: 50,
     },
   ]}
 />

--- a/src/routes/(admin)/account/(menu)/settings/settings_module.svelte
+++ b/src/routes/(admin)/account/(menu)/settings/settings_module.svelte
@@ -18,6 +18,7 @@
     label?: string
     initialValue: string | boolean
     placeholder?: string
+    maxlength?: number
   }
 
   // Module context
@@ -96,6 +97,7 @@
                 ? 'input-error'
                 : ''} input-sm mt-1 input input-bordered w-full max-w-xs mb-3 text-base py-4"
               value={$page.form ? $page.form[field.id] : field.initialValue}
+              maxlength={field.maxlength ? `${field.maxlength}` : null}
             />
           {:else}
             <div class="text-lg mb-3">{field.initialValue}</div>

--- a/src/routes/(admin)/account/api/+page.server.ts
+++ b/src/routes/(admin)/account/api/+page.server.ts
@@ -203,19 +203,29 @@ export const actions = {
     const website = formData.get("website") as string
 
     let validationError
+    const fieldMaxTextLength = 50
     const errorFields = []
     if (!fullName) {
       validationError = "Name is required"
+      errorFields.push("fullName")
+    } else if (fullName.length > fieldMaxTextLength) {
+      validationError = `Name must be less than ${fieldMaxTextLength} charaters`
       errorFields.push("fullName")
     }
     if (!companyName) {
       validationError =
         "Company name is required. If this is a hobby project or personal app, please put your name."
       errorFields.push("companyName")
+    } else if (companyName.length > fieldMaxTextLength) {
+      validationError = `Company name must be less than ${fieldMaxTextLength} charaters`
+      errorFields.push("companyName")
     }
     if (!website) {
       validationError =
         "Company website is required. An app store URL is a good alternative if you don't have a website."
+      errorFields.push("website")
+    } else if (website.length > fieldMaxTextLength) {
+      validationError = `Company website must be less than ${fieldMaxTextLength} charaters`
       errorFields.push("website")
     }
     if (validationError) {

--- a/src/routes/(admin)/account/api/+page.server.ts
+++ b/src/routes/(admin)/account/api/+page.server.ts
@@ -209,7 +209,7 @@ export const actions = {
       validationError = "Name is required"
       errorFields.push("fullName")
     } else if (fullName.length > fieldMaxTextLength) {
-      validationError = `Name must be less than ${fieldMaxTextLength} charaters`
+      validationError = `Name must be less than ${fieldMaxTextLength} characters`
       errorFields.push("fullName")
     }
     if (!companyName) {
@@ -217,7 +217,7 @@ export const actions = {
         "Company name is required. If this is a hobby project or personal app, please put your name."
       errorFields.push("companyName")
     } else if (companyName.length > fieldMaxTextLength) {
-      validationError = `Company name must be less than ${fieldMaxTextLength} charaters`
+      validationError = `Company name must be less than ${fieldMaxTextLength} characters`
       errorFields.push("companyName")
     }
     if (!website) {
@@ -225,7 +225,7 @@ export const actions = {
         "Company website is required. An app store URL is a good alternative if you don't have a website."
       errorFields.push("website")
     } else if (website.length > fieldMaxTextLength) {
-      validationError = `Company website must be less than ${fieldMaxTextLength} charaters`
+      validationError = `Company website must be less than ${fieldMaxTextLength} characters`
       errorFields.push("website")
     }
     if (validationError) {

--- a/src/routes/(admin)/account/create_profile/+page.svelte
+++ b/src/routes/(admin)/account/create_profile/+page.svelte
@@ -57,6 +57,7 @@
               ? 'input-error'
               : ''} mt-1 input input-bordered w-full max-w-xs"
             value={form?.fullName ?? fullName}
+            maxlength="50"
           />
         </div>
 
@@ -73,6 +74,7 @@
               ? 'input-error'
               : ''} mt-1 input input-bordered w-full max-w-xs"
             value={form?.companyName ?? companyName}
+            maxlength="50"
           />
         </div>
 
@@ -89,6 +91,7 @@
               ? 'input-error'
               : ''} mt-1 input input-bordered w-full max-w-xs"
             value={form?.website ?? website}
+            maxlength="50"
           />
         </div>
 


### PR DESCRIPTION
Profile name, company and website inputs should have some upper limit

From the Svelte docs:
<img width="861" alt="image" src="https://github.com/CriticalMoments/CMSaasStarter/assets/6147400/b4d02dab-e0a7-462d-b020-bf4ce4cb9b34">

Example:
<img width="933" alt="image" src="https://github.com/CriticalMoments/CMSaasStarter/assets/6147400/2c9a4413-abc7-42bb-99d7-d67b2bc1160c">
