### PR TITLE
Add more meta tags to head on blog page for better Facebook and Twitter SEO

### DIFF
--- a/src/routes/(marketing)/blog/(posts)/+layout.svelte
+++ b/src/routes/(marketing)/blog/(posts)/+layout.svelte
@@ -2,6 +2,7 @@
   import { page } from "$app/stores"
   import { error } from "@sveltejs/kit"
   import { sortedBlogPosts, type BlogPost } from "./../posts"
+  import { PUBLIC_SITE_NAME } from "$env/static/public"
 
   let currentPost: BlogPost | null = null
   for (const post of sortedBlogPosts) {
@@ -16,14 +17,30 @@
   if (!currentPost) {
     throw error(404, "Blog post not found")
   }
+
+  const pageTitle = currentPost?.title ? currentPost.title : "Not Found"
+  const pageDescription = currentPost?.description ? currentPost.description : "Blog post"
+  const pageUrl = $page.url.origin + $page.url.pathname
 </script>
 
 <svelte:head>
-  <title>{currentPost?.title ? currentPost.title : "Not Found"}</title>
-  <meta
-    name="description"
-    content={currentPost?.description ? currentPost.description : "Blog post"}
-  />
+  <title>{pageTitle}</title>
+  <meta name="description" content={pageDescription} />
+
+  <!-- Facebook -->
+  <meta property="og:title" content={pageTitle}>
+  <meta property="og:description" content={pageDescription}>
+  <meta property="og:site_name" content={PUBLIC_SITE_NAME}>
+  <meta property="og:url" content={pageUrl}>
+  <!-- <meta property="og:image" content="https://samplesite.com/image.jpg"> -->
+
+  <!-- Twitter -->
+  <!-- “summary”, “summary_large_image”, “app”, or “player” -->
+  <meta name="twitter:card" content="summary"> 
+  <meta name="twitter:title" content={pageTitle}>
+  <meta name="twitter:description" content={pageDescription}>
+  <!-- <meta name="twitter:site" content="@samplesite"> -->
+  <!-- <meta name="twitter:image" content="https://samplesite.com/image.jpg"> -->
 </svelte:head>
 
 <article class="prose mx-auto py-12 px-6 font-sans">


### PR DESCRIPTION
Facebook and Twitter have special meta tags that help it render cards in their respective feeds.

Twitter:
![image](https://github.com/CriticalMoments/CMSaasStarter/assets/6147400/b09d07b1-a625-4955-a342-a33677e23f4e)

Facebook:
<img width="741" alt="image" src="https://github.com/CriticalMoments/CMSaasStarter/assets/6147400/2d7396ba-2cf0-4fd7-921f-7edcc6f318fe">