### PR TITLE
Made button optional in the settings page

### DIFF
--- a/src/routes/(admin)/account/(menu)/settings/settings_module.svelte
+++ b/src/routes/(admin)/account/(menu)/settings/settings_module.svelte
@@ -30,8 +30,8 @@
   export let formTarget: string = ""
   export let successTitle = "Success"
   export let successBody = ""
-  export let editButtonTitle: string = ""
-  export let editLink: string = ""
+  export let editButtonTitle: string | null = null
+  export let editLink: string | null = null
   export let saveButtonTitle: string = "Save"
 
   const handleSubmit: SubmitFunction = () => {
@@ -128,7 +128,7 @@
               {/if}
             </button>
           </div>
-        {:else}
+        {:else if editButtonTitle && editLink}
           <!-- !editable -->
           <a href={editLink} class="mt-1">
             <button


### PR DESCRIPTION
Only show edit button when edit link and edit title are defined, making the button optional for when you just want to display some info.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in the settings module by allowing `editButtonTitle` and `editLink` to accept `null` values, improving the handling of absent values.
  
- **Improvements**
	- Refined conditional rendering logic to ensure buttons are displayed only when both `editButtonTitle` and `editLink` are present, enhancing component responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->