### PR TITLE
define setting items in const

### DIFF
--- a/src/routes/(admin)/account/(menu)/settings/+page.svelte
+++ b/src/routes/(admin)/account/(menu)/settings/+page.svelte
@@ -8,6 +8,61 @@
 
   export let data
   let { session, profile } = data
+
+  const settingsModules = [
+    {
+      title: "Profile",
+      fields: [
+        {
+          id: "fullName",
+          label: "Name",
+          initialValue: profile?.full_name ?? "",
+        },
+        {
+          id: "companyName",
+          label: "Company Name",
+          initialValue: profile?.company_name ?? "",
+        },
+        {
+          id: "website",
+          label: "Company Website",
+          initialValue: profile?.website ?? "",
+        },
+      ],
+      editButtonTitle: "Edit Profile",
+      editLink: "/account/settings/edit_profile",
+    },
+    {
+      title: "Email",
+      fields: [{ id: "email", initialValue: session?.user?.email || "" }],
+      editButtonTitle: "Change Email",
+      editLink: "/account/settings/change_email",
+    },
+    {
+      title: "Password",
+      fields: [{ id: "password", initialValue: "••••••••••••••••" }],
+      editButtonTitle: "Change Password",
+      editLink: "/account/settings/change_password",
+    },
+    {
+      title: "Email Subscription",
+      fields: [
+        {
+          id: "subscriptionStatus",
+          initialValue: profile?.unsubscribed ? "Unsubscribed" : "Subscribed",
+        },
+      ],
+      editButtonTitle: "Change Subscription",
+      editLink: "/account/settings/change_email_subscription",
+    },
+    {
+      title: "Danger Zone",
+      fields: [],
+      editButtonTitle: "Delete Account",
+      editLink: "/account/settings/delete_account",
+      dangerous: true,
+    },
+  ]
 </script>
 
 <svelte:head>
@@ -16,60 +71,13 @@
 
 <h1 class="text-2xl font-bold mb-6">Settings</h1>
 
-<SettingsModule
-  title="Profile"
-  editable={false}
-  fields={[
-    { id: "fullName", label: "Name", initialValue: profile?.full_name ?? "" },
-    {
-      id: "companyName",
-      label: "Company Name",
-      initialValue: profile?.company_name ?? "",
-    },
-    {
-      id: "website",
-      label: "Company Website",
-      initialValue: profile?.website ?? "",
-    },
-  ]}
-  editButtonTitle="Edit Profile"
-  editLink="/account/settings/edit_profile"
-/>
-
-<SettingsModule
-  title="Email"
-  editable={false}
-  fields={[{ id: "email", initialValue: session?.user?.email || "" }]}
-  editButtonTitle="Change Email"
-  editLink="/account/settings/change_email"
-/>
-
-<SettingsModule
-  title="Password"
-  editable={false}
-  fields={[{ id: "password", initialValue: "••••••••••••••••" }]}
-  editButtonTitle="Change Password"
-  editLink="/account/settings/change_password"
-/>
-
-<SettingsModule
-  title="Email Subscription"
-  editable={false}
-  fields={[
-    {
-      id: "subscriptionStatus",
-      initialValue: profile?.unsubscribed ? "Unsubscribed" : "Subscribed",
-    },
-  ]}
-  editButtonTitle="Change Subscription"
-  editLink="/account/settings/change_email_subscription"
-/>
-
-<SettingsModule
-  title="Danger Zone"
-  editable={false}
-  dangerous={true}
-  fields={[]}
-  editButtonTitle="Delete Account"
-  editLink="/account/settings/delete_account"
-/>
+{#each settingsModules as module}
+  <SettingsModule
+    title={module.title}
+    editable={false}
+    fields={module.fields}
+    editButtonTitle={module.editButtonTitle}
+    editLink={module.editLink}
+    dangerous={module.dangerous}
+  />
+{/each}


### PR DESCRIPTION
Put setting modules in a const for more user-friendly editing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved settings page structure by consolidating multiple settings modules into a dynamic array-driven approach.
	- Enhanced maintainability and scalability of the settings interface.

- **Bug Fixes**
	- Ensured that the "Danger Zone" module retains its functionality for account deletion.

- **Refactor**
	- Optimized code by reducing redundancy and improving readability through the use of an `{#each}` block for rendering settings modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->