### PR TITLE
More idiomatic supabase auth 

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -13,6 +13,8 @@ declare global {
         user: User | null
         amr: AMREntry[] | null
       }>
+      session: Session | null
+      user: User | null
     }
     interface PageData {
       session: Session | null

--- a/src/routes/(admin)/account/+layout.server.ts
+++ b/src/routes/(admin)/account/+layout.server.ts
@@ -1,21 +1,12 @@
-import { redirect } from "@sveltejs/kit"
 import type { LayoutServerLoad } from "./$types"
 
 export const load: LayoutServerLoad = async ({
-  locals: { supabase, safeGetSession },
+  locals: { session },
   cookies,
 }) => {
-  const { session, user } = await safeGetSession()
-
-  if (!session || !user?.id) {
-    redirect(303, "/login")
+  // Session here is from authGuard hook
+  return {
+    session,
+    cookies: cookies.getAll(),
   }
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select(`*`)
-    .eq("id", user.id)
-    .single()
-
-  return { session, user, profile, cookies: cookies.getAll() }
 }

--- a/src/routes/(marketing)/login/+layout.server.ts
+++ b/src/routes/(marketing)/login/+layout.server.ts
@@ -6,15 +6,13 @@ export const load: LayoutServerLoad = async ({
   locals: { safeGetSession },
   cookies,
 }) => {
-  const { session } = await safeGetSession()
-
   // if the user is already logged in return them to the account page
+  const { session } = await safeGetSession()
   if (session) {
     redirect(303, "/account")
   }
 
   return {
-    session: session,
     url: url.origin,
     cookies: cookies.getAll(),
   }

--- a/src/routes/(marketing)/login/+layout.server.ts
+++ b/src/routes/(marketing)/login/+layout.server.ts
@@ -2,12 +2,11 @@ import { redirect } from "@sveltejs/kit"
 import type { LayoutServerLoad } from "./$types"
 
 export const load: LayoutServerLoad = async ({
-  url,
-  locals: { safeGetSession },
+  locals: { session },
   cookies,
+  url,
 }) => {
   // if the user is already logged in return them to the account page
-  const { session } = await safeGetSession()
   if (session) {
     redirect(303, "/account")
   }


### PR DESCRIPTION

Follow official guide: https://supabase.com/docs/guides/auth/server-side/sveltekit

Differences from guide:

 - only run the auth layout under /account and /login, want fast unauthed marketing pages with no JS
 - Be even more explicit in maing getSession safe by not calling it on the server at all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced session management with a new property for session handling.
	- Introduced authentication middleware to manage access to routes based on user authentication status.
	- Improved logic for handling user sessions and routing to ensure security.

- **Bug Fixes**
	- Resolved redundancy in user declarations to streamline global state management.

- **Refactor**
	- Simplified session retrieval logic to enhance security and efficiency.
	- Adjusted the order of operations in session handling for clarity.

- **Documentation**
	- Updated comments and documentation to reflect changes in session management and authentication processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->