### PR TITLE
Prevent Text Clipping of Descenders in bg-clip-text by Adjusting Padding and Margins

### DIFF
--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -233,7 +233,7 @@
   <div class="hero-content text-center py-12">
     <div class="max-w-xl">
       <div
-        class="text-xl md:text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-primary to-accent mb-4 md:mb-8"
+        class="text-xl md:text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-primary to-accent mb-4 md:mb-8 pb-1"
       >
         SaaS Starter Demo
       </div>

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -300,7 +300,7 @@
   <div class="pt-20 pb-8 px-7">
     <div class="max-w-lg mx-auto text-center">
       <div
-        class="text-3xl md:text-5xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-primary to-accent"
+        class="text-3xl md:text-5xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-primary to-accent pb-2"
       >
         Explore the Features
       </div>
@@ -361,7 +361,7 @@
   <div class="hero-content text-center pb-16 pt-4 px-4">
     <div class="max-w-lg">
       <div
-        class="text-3xl md:text-5xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-primary to-accent mt-4"
+        class="text-3xl md:text-5xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-primary to-accent mt-4 pb-2"
       >
         See it in Action
       </div>

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -233,7 +233,7 @@
   <div class="hero-content text-center py-12">
     <div class="max-w-xl">
       <div
-        class="text-xl md:text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-primary to-accent mb-4 md:mb-8 pb-1"
+        class="text-xl md:text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-primary to-accent mb-3 md:mb-7 pb-1"
       >
         SaaS Starter Demo
       </div>
@@ -304,7 +304,7 @@
       >
         Explore the Features
       </div>
-      <div class="mt-6 text-xl font-bold">
+      <div class="mt-4 text-xl font-bold">
         And try them on this
         <span
           class="underline decoration-secondary decoration-[3px] md:decoration-[4px]"
@@ -366,7 +366,7 @@
         See it in Action
       </div>
       <div
-        class="flex flex-col lg:flex-row mt-8 gap-6 place-content-center content-center"
+        class="flex flex-col lg:flex-row mt-6 gap-6 place-content-center content-center"
       >
         <div class="hidden md:block">
           <a href="https://criticalmoments.io" target="_blank" class="link">


### PR DESCRIPTION
Combining `bg-clip-text` with `text-transparent` can cause descenders (e.g., in characters like "p" and "g") to be clipped. This fix adds padding to ensure descenders are not cut off and adjusts margins to maintain consistent spacing between elements. The changes ensure that the text rendering remains visually intact without affecting the layout's overall appearance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the visual layout of the hero and feature exploration sections by adjusting margins and paddings for improved spacing.
	- Reduced bottom margin for the "SaaS Starter Demo" title and adjusted paddings for better cohesion in design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->