### PR TITLE
Enable node module resolution for TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
+    "moduleResolution": "node",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
Updates tsconfig.json to include "moduleResolution": "node". This change ensures that TypeScript can properly resolve local modules, including Svelte components, which improves the development experience when adding new modules.

Without this setting, TypeScript may fail to find modules, causing issues during local development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated TypeScript configuration to improve module resolution compatibility with Node.js.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->