### PR TITLE
Cancel Stripe subscriptions on account deletion

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,4 +1,5 @@
 import { Session, SupabaseClient, type AMREntry } from "@supabase/supabase-js"
+import type Stripe from "stripe"
 import { Database } from "./DatabaseDefinitions"
 
 // See https://kit.svelte.dev/docs/types#app
@@ -15,6 +16,7 @@ declare global {
       }>
       session: Session | null
       user: User | null
+      stripe: Stripe
     }
     interface PageData {
       session: Session | null

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,8 @@
 // src/hooks.server.ts
-import { PRIVATE_SUPABASE_SERVICE_ROLE } from "$env/static/private"
+import {
+  PRIVATE_STRIPE_API_KEY,
+  PRIVATE_SUPABASE_SERVICE_ROLE,
+} from "$env/static/private"
 import {
   PUBLIC_SUPABASE_ANON_KEY,
   PUBLIC_SUPABASE_URL,
@@ -8,6 +11,7 @@ import { createServerClient } from "@supabase/ssr"
 import { createClient } from "@supabase/supabase-js"
 import type { Handle } from "@sveltejs/kit"
 import { sequence } from "@sveltejs/kit/hooks"
+import Stripe from "stripe"
 
 export const supabase: Handle = async ({ event, resolve }) => {
   event.locals.supabase = createServerClient(
@@ -94,4 +98,11 @@ const authGuard: Handle = async ({ event, resolve }) => {
   return resolve(event)
 }
 
-export const handle: Handle = sequence(supabase, authGuard)
+const stripe: Handle = async ({ event, resolve }) => {
+  event.locals.stripe = new Stripe(PRIVATE_STRIPE_API_KEY, {
+    apiVersion: "2023-08-16",
+  })
+  return resolve(event)
+}
+
+export const handle: Handle = sequence(supabase, authGuard, stripe)


### PR DESCRIPTION
fixes #187

I had this implemented in my fork and noticed this issue in in your repo, so I wanted to chip in.

I'm unsure about storing the `Stripe` instance in `event.locals` in `hook.server.ts` but it seems to me as best approach, which could be accommodated in other parts of the app too, but if you can see some issues with it, I would love your input on it and I can recreate the instance directly in the client module.

Also, what could be up for discussion is whether or not the whole account deletion shouldn't go through if the subscription cancellation is not resolved successfully.

I decided to fail the deletion just so the user had a chance to try it again, ideally by first cancelling in the Stripe's Billing Portal.