### PR TITLE
Fix issue reverting to account page on tab focus

### DIFF
--- a/src/routes/(marketing)/login/sign_in/+page.svelte
+++ b/src/routes/(marketing)/login/sign_in/+page.svelte
@@ -9,7 +9,7 @@
   let { supabase } = data
 
   onMount(() => {
-    supabase.auth.onAuthStateChange((event) => {
+    const { data } = supabase.auth.onAuthStateChange((event) => {
       // Redirect to account after successful login
       if (event == "SIGNED_IN") {
         // Delay needed because order of callback not guaranteed.
@@ -20,6 +20,8 @@
         }, 1)
       }
     })
+
+    return () => data.subscription.unsubscribe()
   })
 </script>
 


### PR DESCRIPTION
This fixes issue #195.

Through trial and error I narrowed down the issue to an auth state change listener added during sign in. Of course this didn't make sense because it occurs when we are loading a completely different path where that `goto` shouldn't be reachable. After adding more logging I discovered it was possible to have duplicate auth listeners after sign in when we should be expecting only one (from `/dashboard/+layout.svelte`).

This was hard to reproduce because refreshing the page caused the duplicate in-memory listener to disappear. It only occurred on fresh login, then loading a sub page, then finally changing tab focus without ever doing a full page reload. After understanding the issue the fix was clear, the listener needs to be removed on unmount like how the other one does it.

Thank you for all the work on this project! It's provided a lot of value to me so I decided to contribute back.